### PR TITLE
Corrected destroy dependencies. Went about it backwards.

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -30,7 +30,7 @@ class UsersController < AuthenticationController
 
   def destroy
     @user = User.find(params[:id])
-    @user.destroy
+    @user.login.destroy
 
     redirect_to users_path
   end

--- a/app/models/college.rb
+++ b/app/models/college.rb
@@ -1,3 +1,5 @@
+# Associations implemented by Cornelius Donley
+
 class College < ActiveRecord::Base
   has_many :graduate_degrees
   has_many :undergraduate_degrees

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,3 +1,5 @@
+# Associations implemented by Cornelius Donley
+
 class Company < ActiveRecord::Base
   has_many :company_infos
 end

--- a/app/models/company_info.rb
+++ b/app/models/company_info.rb
@@ -1,3 +1,5 @@
+# Associations implemented by Cornelius Donley
+
 class CompanyInfo < ActiveRecord::Base
   has_one :company
   belongs_to :giving_back

--- a/app/models/degree.rb
+++ b/app/models/degree.rb
@@ -1,3 +1,5 @@
+# Associations implemented by Cornelius Donley
+
 class Degree < ActiveRecord::Base
   has_many :graduate_degree
   has_many :undergraduate_degree

--- a/app/models/giving_back.rb
+++ b/app/models/giving_back.rb
@@ -1,3 +1,5 @@
+# Associations implemented by Cornelius Donley
+
 class GivingBack < ActiveRecord::Base
   belongs_to :user
   has_one :company_info

--- a/app/models/graduate_degree.rb
+++ b/app/models/graduate_degree.rb
@@ -1,3 +1,5 @@
+# Associations implemented by Cornelius Donley
+
 class GraduateDegree < ActiveRecord::Base
   belongs_to :user
   belongs_to :college

--- a/app/models/login.rb
+++ b/app/models/login.rb
@@ -1,3 +1,6 @@
+# Associations implemented by Cornelius Donley
+# Devise authentication added by Andrew Fredrickson and Ryan Figge
+
 class Login < ActiveRecord::Base
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable

--- a/app/models/login.rb
+++ b/app/models/login.rb
@@ -6,8 +6,8 @@ class Login < ActiveRecord::Base
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable, :authentication_keys => [:logon]
-  has_many :saved_lists
-  has_one :user
+  has_many :saved_lists, :dependent => :destroy
+  has_one :user, :dependent => :destroy
   has_many :surveys
   
   #adds case insensitivity for username

--- a/app/models/saved_list.rb
+++ b/app/models/saved_list.rb
@@ -1,3 +1,5 @@
+# Associations implemented by Cornelius Donley
+
 class SavedList < ActiveRecord::Base
   belongs_to :login
   has_many :saved_list_users, :dependent => :destroy

--- a/app/models/saved_list.rb
+++ b/app/models/saved_list.rb
@@ -1,4 +1,5 @@
 class SavedList < ActiveRecord::Base
   belongs_to :login
+  has_many :saved_list_users, :dependent => :destroy
   has_many :users, through: :saved_list_users
 end

--- a/app/models/saved_list_user.rb
+++ b/app/models/saved_list_user.rb
@@ -1,3 +1,5 @@
+# Associations implemented by Cornelius Donley
+
 class SavedListUser < ActiveRecord::Base
   belongs_to :saved_list
   belongs_to :user

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -1,5 +1,5 @@
 class Survey < ActiveRecord::Base
   belongs_to :login
-  has_many :survey_questions
-  has_many :user_surveys
+  has_many :survey_questions, :dependent => :destroy
+  has_many :user_surveys, :dependent => :destroy
 end

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -1,3 +1,5 @@
+# Associations implemented by Cornelius Donley
+
 class Survey < ActiveRecord::Base
   belongs_to :login
   has_many :survey_questions, :dependent => :destroy

--- a/app/models/survey_question.rb
+++ b/app/models/survey_question.rb
@@ -1,6 +1,6 @@
 class SurveyQuestion < ActiveRecord::Base
   belongs_to :survey
-  has_many :survey_question_options
-  has_many :survey_question_option_choices
-  has_many :user_survey_responses
+  has_many :survey_question_options, :dependent => :destroy
+  has_many :survey_question_option_choices, :dependent => :destroy
+  has_many :user_survey_responses, :dependent => :destroy
 end

--- a/app/models/survey_question.rb
+++ b/app/models/survey_question.rb
@@ -1,3 +1,5 @@
+# Associations implemented by Cornelius Donley
+
 class SurveyQuestion < ActiveRecord::Base
   belongs_to :survey
   has_many :survey_question_options, :dependent => :destroy

--- a/app/models/survey_question_option.rb
+++ b/app/models/survey_question_option.rb
@@ -1,4 +1,4 @@
 class SurveyQuestionOption < ActiveRecord::Base
   belongs_to :survey_question
-  has_many :user_survey_responses
+  has_many :user_survey_responses, :dependent => :destroy
 end

--- a/app/models/survey_question_option.rb
+++ b/app/models/survey_question_option.rb
@@ -1,3 +1,5 @@
+# Associations implemented by Cornelius Donley
+
 class SurveyQuestionOption < ActiveRecord::Base
   belongs_to :survey_question
   has_many :user_survey_responses, :dependent => :destroy

--- a/app/models/survey_question_option_choice.rb
+++ b/app/models/survey_question_option_choice.rb
@@ -1,3 +1,5 @@
+# Associations implemented by Cornelius Donley
+
 class SurveyQuestionOptionChoice < ActiveRecord::Base
   belongs_to :survey_question
   has_many :user_survey_responses, :dependent => :destroy

--- a/app/models/survey_question_option_choice.rb
+++ b/app/models/survey_question_option_choice.rb
@@ -1,4 +1,4 @@
 class SurveyQuestionOptionChoice < ActiveRecord::Base
   belongs_to :survey_question
-  has_many :user_survey_responses
+  has_many :user_survey_responses, :dependent => :destroy
 end

--- a/app/models/undergraduate_degree.rb
+++ b/app/models/undergraduate_degree.rb
@@ -1,3 +1,5 @@
+# Associations implemented by Cornelius Donley
+
 class UndergraduateDegree < ActiveRecord::Base
   belongs_to :user
   belongs_to :college

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,10 +1,11 @@
 class User < ActiveRecord::Base
   belongs_to :login
   belongs_to :company_info
-  has_many :saved_lists, through: :saved_list_users
-  has_many :giving_backs
-  has_many :user_phones
-  has_many :graduate_degrees
-  has_many :undergraduate_degrees
-
+  has_many :saved_list_users, :dependent => :destroy
+  has_many :saved_lists, :through => :saved_list_users
+  has_many :giving_backs, :dependent => :destroy
+  has_many :user_phones, :dependent => :destroy
+  has_many :graduate_degrees, :dependent => :destroy
+  has_many :undergraduate_degrees, :dependent => :destroy
+  has_many :user_surveys, :dependent => :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,5 @@
+# Associations implemented by Cornelius Donley
+
 class User < ActiveRecord::Base
   belongs_to :login
   belongs_to :company_info

--- a/app/models/user_phone.rb
+++ b/app/models/user_phone.rb
@@ -1,3 +1,5 @@
+# Associations implemented by Cornelius Donley
+
 class UserPhone < ActiveRecord::Base
   belongs_to :user
 end

--- a/app/models/user_survey.rb
+++ b/app/models/user_survey.rb
@@ -1,5 +1,5 @@
 class UserSurvey < ActiveRecord::Base
   belongs_to :user
   belongs_to :survey
-  has_many :user_survey_responses
+  has_many :user_survey_responses, :dependent => :destroy
 end

--- a/app/models/user_survey.rb
+++ b/app/models/user_survey.rb
@@ -1,3 +1,5 @@
+# Associations implemented by Cornelius Donley
+
 class UserSurvey < ActiveRecord::Base
   belongs_to :user
   belongs_to :survey

--- a/app/models/user_survey_response.rb
+++ b/app/models/user_survey_response.rb
@@ -1,3 +1,5 @@
+# Associations implemented by Cornelius Donley
+
 class UserSurveyResponse < ActiveRecord::Base
   belongs_to :user_survey
   belongs_to :survey_question

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -14,7 +14,7 @@
     <% @users.each do |user| %>
       <tr>
         <td><%= user.login.first_name %> <%= user.login.last_name %></td>
-        <td><%= user.email_addr %></td>
+        <td><%= user.login.email %></td>
         <% if user.status == 1 %>
           <td> Enrolled </td>
         <% else %>

--- a/db/migrate/20150511080735_create_logins.rb
+++ b/db/migrate/20150511080735_create_logins.rb
@@ -1,3 +1,6 @@
+# Created by Christian Winger
+# Initial table create
+
 class CreateLogins < ActiveRecord::Migration
   def change
     create_table :logins do |t|

--- a/db/migrate/20150511080852_create_saved_lists.rb
+++ b/db/migrate/20150511080852_create_saved_lists.rb
@@ -1,3 +1,6 @@
+# Created by Christian Winger
+# Initial table create
+
 class CreateSavedLists < ActiveRecord::Migration
   def change
     create_table :saved_lists do |t|

--- a/db/migrate/20150511081044_create_company_infos.rb
+++ b/db/migrate/20150511081044_create_company_infos.rb
@@ -1,3 +1,6 @@
+# Created by Christian Winger
+# Initial table create
+
 class CreateCompanyInfos < ActiveRecord::Migration
   def change
     create_table :company_infos do |t|

--- a/db/migrate/20150511081045_create_companies.rb
+++ b/db/migrate/20150511081045_create_companies.rb
@@ -1,3 +1,6 @@
+# Created by Christian Winger
+# Initial table create
+
 class CreateCompanies < ActiveRecord::Migration
   def change
     create_table :companies do |t|

--- a/db/migrate/20150511081527_create_users.rb
+++ b/db/migrate/20150511081527_create_users.rb
@@ -1,3 +1,6 @@
+# Created by Christian Winger
+# Initial table create
+
 class CreateUsers < ActiveRecord::Migration
   def change
     create_table :users do |t|

--- a/db/migrate/20150511081709_create_saved_list_users.rb
+++ b/db/migrate/20150511081709_create_saved_list_users.rb
@@ -1,3 +1,6 @@
+# Created by Christian Winger
+# Initial table create
+
 class CreateSavedListUsers < ActiveRecord::Migration
   def change
     create_table :saved_list_users do |t|

--- a/db/migrate/20150511081939_create_user_phones.rb
+++ b/db/migrate/20150511081939_create_user_phones.rb
@@ -1,3 +1,6 @@
+# Created by Christian Winger
+# Initial table create
+
 class CreateUserPhones < ActiveRecord::Migration
   def change
     create_table :user_phones do |t|

--- a/db/migrate/20150511082026_create_degrees.rb
+++ b/db/migrate/20150511082026_create_degrees.rb
@@ -1,3 +1,6 @@
+# Created by Christian Winger
+# Initial table create
+
 class CreateDegrees < ActiveRecord::Migration
   def change
     create_table :degrees do |t|

--- a/db/migrate/20150511082615_create_colleges.rb
+++ b/db/migrate/20150511082615_create_colleges.rb
@@ -1,3 +1,6 @@
+# Created by Christian Winger
+# Initial table create
+
 class CreateColleges < ActiveRecord::Migration
   def change
     create_table :colleges do |t|

--- a/db/migrate/20150511082633_create_undergraduate_degrees.rb
+++ b/db/migrate/20150511082633_create_undergraduate_degrees.rb
@@ -1,3 +1,6 @@
+# Created by Christian Winger
+# Initial table create
+
 class CreateUndergraduateDegrees < ActiveRecord::Migration
   def change
     create_table :undergraduate_degrees do |t|

--- a/db/migrate/20150511082649_create_graduate_degrees.rb
+++ b/db/migrate/20150511082649_create_graduate_degrees.rb
@@ -1,3 +1,6 @@
+# Created by Christian Winger
+# Initial table create
+
 class CreateGraduateDegrees < ActiveRecord::Migration
   def change
     create_table :graduate_degrees do |t|

--- a/db/migrate/20150511083046_create_giving_backs.rb
+++ b/db/migrate/20150511083046_create_giving_backs.rb
@@ -1,3 +1,6 @@
+# Created by Christian Winger
+# Initial table create
+
 class CreateGivingBacks < ActiveRecord::Migration
   def change
     create_table :giving_backs do |t|

--- a/db/migrate/20150511083240_create_surveys.rb
+++ b/db/migrate/20150511083240_create_surveys.rb
@@ -1,3 +1,6 @@
+# Created by Christian Winger
+# Initial table create
+
 class CreateSurveys < ActiveRecord::Migration
   def change
     create_table :surveys do |t|

--- a/db/migrate/20150511083422_create_survey_questions.rb
+++ b/db/migrate/20150511083422_create_survey_questions.rb
@@ -1,3 +1,6 @@
+# Created by Christian Winger
+# Initial table create
+
 class CreateSurveyQuestions < ActiveRecord::Migration
   def change
     create_table :survey_questions do |t|

--- a/db/migrate/20150511083746_create_survey_question_option_choices.rb
+++ b/db/migrate/20150511083746_create_survey_question_option_choices.rb
@@ -1,3 +1,6 @@
+# Created by Christian Winger
+# Initial table create
+
 class CreateSurveyQuestionOptionChoices < ActiveRecord::Migration
   def change
     create_table :survey_question_option_choices do |t|

--- a/db/migrate/20150511083838_create_survey_question_options.rb
+++ b/db/migrate/20150511083838_create_survey_question_options.rb
@@ -1,3 +1,6 @@
+# Created by Christian Winger
+# Initial table create
+
 class CreateSurveyQuestionOptions < ActiveRecord::Migration
   def change
     create_table :survey_question_options do |t|

--- a/db/migrate/20150511084015_create_user_surveys.rb
+++ b/db/migrate/20150511084015_create_user_surveys.rb
@@ -1,3 +1,6 @@
+# Created by Christian Winger
+# Initial table create
+
 class CreateUserSurveys < ActiveRecord::Migration
   def change
     create_table :user_surveys do |t|

--- a/db/migrate/20150511084452_create_user_survey_responses.rb
+++ b/db/migrate/20150511084452_create_user_survey_responses.rb
@@ -1,3 +1,6 @@
+# Created by Christian Winger
+# Initial table create
+
 class CreateUserSurveyResponses < ActiveRecord::Migration
   def change
     create_table :user_survey_responses do |t|

--- a/db/migrate/20150513170955_change_giving_back.rb
+++ b/db/migrate/20150513170955_change_giving_back.rb
@@ -1,3 +1,6 @@
+# Created by Cornelius Donley
+# Changed text response from type string to type text
+
 class ChangeGivingBack < ActiveRecord::Migration
   def change
     change_table :giving_backs do |t|

--- a/db/migrate/20150513171346_change_graduate_degrees.rb
+++ b/db/migrate/20150513171346_change_graduate_degrees.rb
@@ -1,3 +1,6 @@
+# Created by Cornelius Donley
+# Changed graduation date to type date
+
 class ChangeGraduateDegrees < ActiveRecord::Migration
   def change
     change_table :graduate_degrees do |t|

--- a/db/migrate/20150513171556_change_saved_lists.rb
+++ b/db/migrate/20150513171556_change_saved_lists.rb
@@ -1,3 +1,6 @@
+# Created by Cornelius Donley
+# Changed date saved column to type date
+
 class ChangeSavedLists < ActiveRecord::Migration
   def change
     change_table :saved_lists do |t|

--- a/db/migrate/20150513171627_change_survey_question_option_choices.rb
+++ b/db/migrate/20150513171627_change_survey_question_option_choices.rb
@@ -1,3 +1,6 @@
+# Created by Cornelius Donley
+# Changed text response from type string to type text
+
 class ChangeSurveyQuestionOptionChoices < ActiveRecord::Migration
   def change
     change_table :survey_question_option_choices do |t|

--- a/db/migrate/20150513171643_change_survey_question_options.rb
+++ b/db/migrate/20150513171643_change_survey_question_options.rb
@@ -1,3 +1,6 @@
+# Created by Cornelius Donley
+# Changed text response from type string to type text
+
 class ChangeSurveyQuestionOptions < ActiveRecord::Migration
   def change
     change_table :survey_question_options do |t|

--- a/db/migrate/20150513171659_change_survey_questions.rb
+++ b/db/migrate/20150513171659_change_survey_questions.rb
@@ -1,3 +1,6 @@
+# Created by Cornelius Donley
+# Changed text response from type string to type text
+
 class ChangeSurveyQuestions < ActiveRecord::Migration
   def change
     change_table :survey_questions do |t|

--- a/db/migrate/20150513171714_change_surveys.rb
+++ b/db/migrate/20150513171714_change_surveys.rb
@@ -1,3 +1,7 @@
+# Created by Cornelius Donley
+# Changed text response from type string to type text
+# Changed date column to type date
+
 class ChangeSurveys < ActiveRecord::Migration
   def change
     change_table :surveys do |t|

--- a/db/migrate/20150513171740_change_undergraduate_degrees.rb
+++ b/db/migrate/20150513171740_change_undergraduate_degrees.rb
@@ -1,3 +1,5 @@
+# Created by Cornelius Donley
+# Changed graduation date to type date
 class ChangeUndergraduateDegrees < ActiveRecord::Migration
   def change
     change_table :undergraduate_degrees do |t|

--- a/db/migrate/20150513171816_change_user_surveys.rb
+++ b/db/migrate/20150513171816_change_user_surveys.rb
@@ -1,3 +1,5 @@
+# Created by Cornelius Donley
+# Changed text response from type string to type text
 class ChangeUserSurveys < ActiveRecord::Migration
   def change
     change_table :user_survey_responses do |t|

--- a/db/migrate/20150513171829_change_users.rb
+++ b/db/migrate/20150513171829_change_users.rb
@@ -1,3 +1,7 @@
+# Created by Cornelius Donley
+# Combined date fields into single column with type date
+# Changed salary to type integer
+
 class ChangeUsers < ActiveRecord::Migration
   def change
     change_table :users do |t|

--- a/db/migrate/20150515181333_add_password_to_login.rb
+++ b/db/migrate/20150515181333_add_password_to_login.rb
@@ -1,3 +1,6 @@
+# Created by Cornelius Donley
+# Fixed spelling mistake
+
 class AddPasswordToLogin < ActiveRecord::Migration
   def change
     change_table :logins do |t|

--- a/db/migrate/20150521015919_add_street_to_users.rb
+++ b/db/migrate/20150521015919_add_street_to_users.rb
@@ -1,3 +1,5 @@
+# Created by Christian Winger
+# Street missing from initial table create
 class AddStreetToUsers < ActiveRecord::Migration
   def change
     change_table :users do |t|

--- a/db/migrate/20150527185459_add_middle_initial_to_login.rb
+++ b/db/migrate/20150527185459_add_middle_initial_to_login.rb
@@ -1,3 +1,6 @@
+# Created by Cornelius Donley
+# Middle initial missing from initial table create
+
 class AddMiddleInitialToLogin < ActiveRecord::Migration
   def change
     change_table :logins do |t|

--- a/db/migrate/20150530230638_add_nccid_to_users.rb
+++ b/db/migrate/20150530230638_add_nccid_to_users.rb
@@ -1,3 +1,5 @@
+# Created by Christian Winger
+
 class AddNccidToUsers < ActiveRecord::Migration
   def change
     add_column :users, :nccid, :string

--- a/db/migrate/20150604044306_remove_nccid_from_users.rb
+++ b/db/migrate/20150604044306_remove_nccid_from_users.rb
@@ -1,4 +1,5 @@
-#Created by Cornelius Donley
+# Created by Cornelius Donley
+# NCCID associated with a User account deemed a security issue
 
 class RemoveNccidFromUsers < ActiveRecord::Migration
   def change

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,5 @@
+# Seed data created by Cornelius Donley and Christian Winger
+
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
 #


### PR DESCRIPTION
When a Login record for a Worker/Admin is destroyed, the SavedLists and SavedListUsers tables for that Login are also destroyed.
When a Login record for a User is destroyed, the User, SavedListUsers, UserPhones, UndergraduateDegrees, GraduateDegrees, and GivingBacks tables for that User are also destroyed.
The Surveys created by a Worker are not destroyed and the CompanyInfo created by a User is not destroyed; this is by design.
